### PR TITLE
feat: add the streamlit interface

### DIFF
--- a/client_app/app.py
+++ b/client_app/app.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+Client App Module
+"""
+import streamlit as st
+from client_app.networking import send_dictionary, send_text_file
+
+def main():
+    """
+    Main Streamlit Client Application
+    """
+    st.title("Client Application")
+
+    action = st.selectbox("Action", ["Send Text File", "Send Dictionary"], key="action_select")
+
+    if action == "Send Dictionary":
+        key = st.text_input("Key", max_chars=50, key="dict_key")
+        value = st.number_input("Value", min_value=0, max_value=100, step=1, key="dict_value")
+        serialization_format = st.selectbox(
+            "Serialization Format", 
+            ["binary", "json", "xml"], 
+            key="dict_serialize_format"
+        )
+
+        if st.button(
+            "Send Dictionary", 
+            key="send_dict_btn", 
+            disabled=value < 1 or value > 100 or len(key) == 0 or len(key) > 50
+            ):
+            dictionary = {'key': key, 'value': value}
+            send_dictionary(dictionary, serialization_format)
+            st.success("Dictionary sent successfully!")
+
+    elif action == "Send Text File":
+        file = st.file_uploader("Choose a text file", type="txt", key="file_uploader")
+        encrypt_data = st.checkbox("Encrypt File", value=True, key="encrypt_checkbox")
+
+        if file and st.button("Send Text File", key="send_file_btn"):
+            file_path = f"temp_{file.name}"
+            with open(file_path, 'wb') as f:
+                f.write(file.read())
+            send_text_file(file_path, encrypt_data)
+            st.success("Text file sent successfully!")
+
+if __name__ == "__main__":
+    main()

--- a/client_app/tests/test_app.py
+++ b/client_app/tests/test_app.py
@@ -1,0 +1,65 @@
+"""
+Integration tests for the Streamlit application.
+"""
+import unittest
+from unittest.mock import patch, mock_open, MagicMock
+from streamlit.testing.v1 import AppTest
+
+class TestStreamlitApp(unittest.TestCase):
+    """
+    Test the functionality of the Streamlit client application.
+    """
+    def setUp(self):
+        """
+        Initialize AppTest and run the Streamlit app.
+        """
+        self.at = AppTest.from_file("../app.py", default_timeout=5)
+        self.at.run()
+
+    def print_markdown_elements(self):
+        """
+        Helper function to print markdown elements for debugging.
+        """
+        print("Markdown Elements:")
+        for elem in self.at.markdown:
+            print(elem.value)
+
+    @patch('client_app.networking.send_dictionary')
+    @patch('streamlit.success')
+    def test_send_dictionary(self, mock_success, mock_send_dictionary):
+        """
+        Test sending a dictionary via the Streamlit app.
+        """
+        self.at.selectbox("action_select").select("Send Dictionary").run()
+        self.at.text_input("dict_key").set_value("test").run()
+        self.at.number_input("dict_value").set_value(42).run()
+        self.at.selectbox("dict_serialize_format").select("json").run()
+        self.at.button("send_dict_btn").click().run()
+
+        mock_send_dictionary.assert_called_once_with({'key': 'test', 'value': 42}, 'json')
+        mock_success.assert_called_once_with("Dictionary sent successfully!")
+
+    @patch('client_app.networking.send_text_file')
+    @patch('builtins.open', new_callable=mock_open, read_data=b'test file data')
+    @patch('streamlit.success')
+    def test_send_text_file(self, mock_success, mock_file, mock_send_text_file):
+        """
+        Test sending a text file via the Streamlit app.
+        """
+        with patch('streamlit.file_uploader') as mock_file_uploader:
+            mock_file_uploader.return_value = MagicMock(name="example.txt")
+
+            self.at.selectbox("action_select").select("Send Text File").run()
+            mock_file_uploader.return_value = MagicMock()
+            mock_file_uploader().name = "example.txt"
+            mock_file_uploader().getvalue.return_value = b"example file content"
+
+            self.at.checkbox("encrypt_checkbox").check().run()
+            self.at.button("send_file_btn").click().run()
+
+            mock_send_text_file.assert_called_once_with('temp_example.txt', True)
+
+            mock_success.assert_called_once_with("Text file sent successfully!")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Add the Streamlit user interface
- Provide options for uploading and sending a text file (plain text or encrypted)
- Provide a dictionary option for sending a key-value pair with `binary`, `JSON` and `XML` as serialization options
- Create an integration testing module with mocks to test interactions between UI & Server